### PR TITLE
Config (second pass)

### DIFF
--- a/specifications/config.json
+++ b/specifications/config.json
@@ -33,12 +33,6 @@
     "oauth2":{
       "enabled": false,
       "uri": "/oauth/token",
-      "password":{
-        "enabled": true,
-        "accessToken":{
-          "ttl": 3600
-        }
-      },
       "client_credentials":{
         "enabled": true,
         "accessToken":{
@@ -48,8 +42,6 @@
     },
     "accessTokenCookie":{
       "name": "access_token",
-      "ttl": 3600,
-      "tti": 900,
       "httpOnly": true,
       "secure": null,
       "path": "/",

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -1,15 +1,35 @@
 {
   "client": {
-    "apiKeyFile": "/path/to/file",
-    "apiKeyId": "xxx",
-    "apiKeySecret": "xxx",
-    "baseUrl": "https://api.stormpath.com/v1"
+    "apiKey":{
+      "file":"",
+      "id":"",
+      "secret":""
+    },
+    "cacheManager":{
+      "defaultTtl": 300,
+      "defaultTti": 300,
+      "caches": {
+        "account": {
+          "ttl": 300,
+          "tti": 300
+        }
+      }
+    },
+    "baseUrl": "https://api.stormpath.com/v1",
+    "connectionTimeout": 30,
+    "authenticationScheme": "SAUTHC1", // or "BASIC"
+    "proxy":{
+      "port": "",
+      "host": "",
+      "username": "",
+      "password": ""
+    }
   },
   "application": {
     "name": "test",
     "href": "https://..."
   },
-  "api": {
+  "web": {
     "oauth2":{
       "enabled": false,
       "uri": "/oauth/token",
@@ -24,19 +44,14 @@
         "accessToken":{
           "ttl": 3600
         }
-      },
-    },
-  },
-  "web": {
-    "admin": {
-      "enabled": false,
-      "uri": "/admin"  // if you visit this URI and youre a stormpath admin in the admins directory, you get redirected to stormpath admin dashboard panel for the current application
+      }
     },
     "register": {
       "enabled": false,
       "uri": "/register",
       "nextUri": "/",
       "templatePath": "/path/to/template.jade",
+      "autoAuthorize": false,
       "fields": [
         {
           "name": "givenName",
@@ -57,12 +72,12 @@
           "type": "password"
         },
       ],
-      "verifyEmail": {
-        "autoLogin": true,
-        "uri": "/verify",
-        "nextUri": "/",
-        "templatePath": "/path/to/template.jade"
-      }
+    },
+    "verifyEmail": {
+      "autoLogin": true,
+      "uri": "/verify",
+      "nextUri": "/",
+      "templatePath": "/path/to/template.jade"
     },
     "login": {
       "enabled": false,
@@ -80,16 +95,20 @@
       "enabled": false,
       "uri": "/forgot",
       "templatePath": "/path/to/template.jade",
-      "change": {
-        "autoLogin": true,
-        "uri": "/change",
-        "templatePath": "/path/to/template.jade",
-        "nextUri": "/"
-      }
+    },
+    "changePassword": {
+      "enabled": false,
+      "autoLogin": true,
+      "uri": "/change",
+      "templatePath": "/path/to/template.jade",
+      "nextUri": "/"
     },
     "idSite": {
       "enabled": false,  // if this is true, then when a visitor hits /login or /register, we auto redirect them to the id site
-      "callbackUri": "https://mysite.com/idsite"   // this is the authorized redirectUri that will create the session
+      "uri": "/idSiteResult",
+      "loginUri": "",
+      "forgotUri": "/#/forgot",
+      "registerUri": "/#/register"
     }
   }
 }

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -46,6 +46,14 @@
         }
       }
     },
+    "session":{
+      "ttl": 3600,
+      "tti": 900,
+      "httpOnly": true,
+      "secure": null,
+      "path": "/",
+      "domain": null
+    },
     "register": {
       "enabled": false,
       "uri": "/register",

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -113,6 +113,10 @@
       "loginUri": "",
       "forgotUri": "/#/forgot",
       "registerUri": "/#/register"
+    },
+    "me": {
+      "enabled": false,
+      "uri": "/me"
     }
   }
 }

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -73,7 +73,7 @@
     },
     "idSite": {
       "enabled": false,  // if this is true, then when a visitor hits /login or /register, we auto redirect them to the id site
-      "uri": "/idsite"   // this is the authorized redirectUri that will create the session
+      "callbackUri": "https://mysite.com/idsite"   // this is the authorized redirectUri that will create the session
     }
   }
 }

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -3,6 +3,7 @@
     "apiKeyFile": "/path/to/file",
     "apiKeyId": "xxx",
     "apiKeySecret": "xxx",
+    "baseUrl": "https://api.stormpath.com/v1"
   },
   "application": {
     "name": "test",

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -52,26 +52,15 @@
       "uri": "/register",
       "nextUri": "/",
       "autoAuthorize": false,
-      "fields": [
-        {
-          "name": "givenName",
-          "required": true
-        },
-        {
-          "name": "surname",
-          "required": true
-        },
-        {
-          "name": "email",
-          "required": true,
-          "type": "email"
-        },
-        {
-          "name": "password",
-          "required": true,
-          "type": "password"
-        },
-      ],
+      "fields": {
+        "givenName": { "required": true },
+        "middleName": { "required": false },
+        "surname": { "required": true },
+        "email": { "required": true, "type": "email" },
+        "password": { "required": true, "type": "password" },
+        "passwordConfirm": { "required": false, "type": "password" }
+      },
+      "fieldOrder": [ "givenName", "middleName", "surname", "email", "password", "passwordConfirm" ],
       "view": "register"
     },
     "verifyEmail": {

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -46,7 +46,7 @@
         }
       }
     },
-    "tokenCookie":{
+    "accessTokenCookie":{
       "name": "access_token",
       "ttl": 3600,
       "tti": 900,

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -9,7 +9,22 @@
     "href": "https://..."
   },
   "api": {
-
+    "oauth2":{
+      "enabled": false,
+      "uri": "/oauth/token",
+      "password":{
+        "enabled": true,
+        "accessToken":{
+          "ttl": 3600
+        }
+      },
+      "client_credentials":{
+        "enabled": true,
+        "accessToken":{
+          "ttl": 3600
+        }
+      },
+    },
   },
   "web": {
     "admin": {

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -80,20 +80,20 @@
           "type": "password"
         },
       ],
-      "templateName": "register"
+      "view": "register"
     },
     "verifyEmail": {
       "autoLogin": true,
       "uri": "/verify",
       "nextUri": "/",
-      "templateName": "verify"
+      "view": "verify"
     },
     "login": {
       "enabled": false,
       "autoLogin": true,
       "uri": "/login",
       "nextUri": "/",
-      "templateName": "login"
+      "view": "login"
     },
     "logout": {
       "enabled": false,
@@ -103,14 +103,14 @@
     "forgotPassword": {
       "enabled": false,
       "uri": "/forgot",
-      "templateName": "forgot-password"
+      "view": "forgot-password"
     },
     "changePassword": {
       "enabled": false,
       "autoLogin": true,
       "uri": "/change",
       "nextUri": "/",
-      "templateName": "change-password"
+      "view": "change-password"
     },
     "idSite": {
       "enabled": false,  // if this is true, then when a visitor hits /login or /register, we auto redirect them to the id site

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -3,8 +3,10 @@
     "apiKeyFile": "/path/to/file",
     "apiKeyId": "xxx",
     "apiKeySecret": "xxx",
-    "applicationName": "test",
-    "applicationHref": "https://...",
+  },
+  "application": {
+    "name": "test",
+    "href": "https://..."
   },
   "api": {
 

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -46,8 +46,8 @@
         }
       }
     },
-    "session":{
-      "cookieName": "access_token",
+    "tokenCookie":{
+      "name": "access_token",
       "ttl": 3600,
       "tti": 900,
       "httpOnly": true,
@@ -80,17 +80,20 @@
           "type": "password"
         },
       ],
+      "templateName": "register"
     },
     "verifyEmail": {
       "autoLogin": true,
       "uri": "/verify",
-      "nextUri": "/"
+      "nextUri": "/",
+      "templateName": "verify"
     },
     "login": {
       "enabled": false,
       "autoLogin": true,
       "uri": "/login",
-      "nextUri": "/"
+      "nextUri": "/",
+      "templateName": "login"
     },
     "logout": {
       "enabled": false,
@@ -99,13 +102,15 @@
     },
     "forgotPassword": {
       "enabled": false,
-      "uri": "/forgot"
+      "uri": "/forgot",
+      "templateName": "forgot-password"
     },
     "changePassword": {
       "enabled": false,
       "autoLogin": true,
       "uri": "/change",
-      "nextUri": "/"
+      "nextUri": "/",
+      "templateName": "change-password"
     },
     "idSite": {
       "enabled": false,  // if this is true, then when a visitor hits /login or /register, we auto redirect them to the id site

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -47,6 +47,7 @@
       }
     },
     "session":{
+      "cookieName": "access_token",
       "ttl": 3600,
       "tti": 900,
       "httpOnly": true,

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -83,8 +83,7 @@
     "verifyEmail": {
       "autoLogin": true,
       "uri": "/verify",
-      "nextUri": "/",
-      "templatePath": "/path/to/template.jade"
+      "nextUri": "/"
     },
     "login": {
       "enabled": false,

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -1,0 +1,77 @@
+{
+  "client": {
+    "apiKeyFile": "/path/to/file",
+    "apiKeyId": "xxx",
+    "apiKeySecret": "xxx",
+    "applicationName": "test",
+    "applicationHref": "https://...",
+  },
+  "api": {
+
+  },
+  "web": {
+    "admin": {
+      "enabled": false,
+      "uri": "/admin"  // if you visit this URI and youre a stormpath admin in the admins directory, you get redirected to stormpath admin dashboard panel for the current application
+    },
+    "register": {
+      "enabled": false,
+      "uri": "/register",
+      "nextUri": "/",
+      "templatePath": "/path/to/template.jade",
+      "fields": [
+        {
+          "name": "givenName",
+          "required": true
+        },
+        {
+          "name": "surname",
+          "required": true
+        },
+        {
+          "name": "email",
+          "required": true,
+          "type": "email"
+        },
+        {
+          "name": "password",
+          "required": true,
+          "type": "password"
+        },
+      ],
+      "verifyEmail": {
+        "autoLogin": true,
+        "uri": "/verify",
+        "nextUri": "/",
+        "templatePath": "/path/to/template.jade"
+      }
+    },
+    "login": {
+      "enabled": false,
+      "autoLogin": true,
+      "uri": "/login",
+      "nextUri": "/",
+      "templatePath": "/path/to/template.jade",
+    },
+    "logout": {
+      "enabled": false,
+      "uri": "/logout",
+      "nextUri": "/"
+    },
+    "forgotPassword": {
+      "enabled": false,
+      "uri": "/forgot",
+      "templatePath": "/path/to/template.jade",
+      "change": {
+        "autoLogin": true,
+        "uri": "/change",
+        "templatePath": "/path/to/template.jade",
+        "nextUri": "/"
+      }
+    },
+    "idSite": {
+      "enabled": false,  // if this is true, then when a visitor hits /login or /register, we auto redirect them to the id site
+      "uri": "/idsite"   // this is the authorized redirectUri that will create the session
+    }
+  }
+}

--- a/specifications/config.json
+++ b/specifications/config.json
@@ -50,7 +50,6 @@
       "enabled": false,
       "uri": "/register",
       "nextUri": "/",
-      "templatePath": "/path/to/template.jade",
       "autoAuthorize": false,
       "fields": [
         {
@@ -83,8 +82,7 @@
       "enabled": false,
       "autoLogin": true,
       "uri": "/login",
-      "nextUri": "/",
-      "templatePath": "/path/to/template.jade",
+      "nextUri": "/"
     },
     "logout": {
       "enabled": false,
@@ -93,14 +91,12 @@
     },
     "forgotPassword": {
       "enabled": false,
-      "uri": "/forgot",
-      "templatePath": "/path/to/template.jade",
+      "uri": "/forgot"
     },
     "changePassword": {
       "enabled": false,
       "autoLogin": true,
       "uri": "/change",
-      "templatePath": "/path/to/template.jade",
       "nextUri": "/"
     },
     "idSite": {


### PR DESCRIPTION
Ping @rdegges and @omgitstom 

This is what config.json looks like after a review with @lhazlewood 

Please compare to #4 and provide feedback.

Things that new:
- Adding client options for the following
  - Cache configuration
  - Connection timeout
  - Proxy settings
- Added the "login", "forgot", and "register" properties to the
  ID Site config (these are deep links into the ID Site UI, that
  are used when sending users from the service provider)

Changes for review:
- Flattened the web options, so that we don't have nested route
  configurations
- Moved the oauth endpoint spec into web.  We feel like there's isn't
  a reason for it to hang off by itself under "api"
