### PR TITLE
Clarify default cache configuration

### DIFF
--- a/specifications/config.md
+++ b/specifications/config.md
@@ -53,7 +53,7 @@ application:
   href: null
 ```
 
-See the [stormpath.yaml](#stormpath-json-yaml) section below for examples of properties not specified in the default configuration.
+>> :bulb: See the [stormpath.yaml](#stormpathjsonyaml) section below for examples of properties not specified in the default configuration.
 
 ## Files
 
@@ -85,10 +85,14 @@ client:
     defaultTtl: 300
     defaultTti: 300
     caches:
+      
+      # Resource cache configurations, as needed.
+      # These are used to override the default TTL/TTI settings
+      # for a particular resource type.
       account:
         ttl: 300
         tti: 300
-      # Additional resource cache configurations, as needed.
+      
   baseUrl: "https://api.stormpath.com/v1"
   connectionTimeout: 30
   authenticationScheme: "SAUTHC1"

--- a/specifications/config.md
+++ b/specifications/config.md
@@ -27,7 +27,7 @@ The order in which the configuration should be loaded.
 
 ## Default configuration
 
-The default configuration structure. Represented as [YAML](https://en.wikipedia.org/wiki/YAML) below.
+The default configuration, represented as [YAML](https://en.wikipedia.org/wiki/YAML):
 
 ```yaml
 ---
@@ -39,10 +39,7 @@ client:
   cacheManager:
     defaultTtl: 300
     defaultTti: 300
-    caches:
-      account:
-        ttl: 300
-        tti: 300
+    caches: { }
   baseUrl: "https://api.stormpath.com/v1"
   connectionTimeout: 30
   authenticationScheme: "SAUTHC1"
@@ -89,6 +86,7 @@ client:
       account:
         ttl: 300
         tti: 300
+      # Additional resource cache configurations, as needed.
   baseUrl: "https://api.stormpath.com/v1"
   connectionTimeout: 30
   authenticationScheme: "SAUTHC1"

--- a/specifications/config.md
+++ b/specifications/config.md
@@ -27,7 +27,7 @@ The order in which the configuration should be loaded.
 
 ## Default configuration
 
-The default configuration, represented as [YAML](https://en.wikipedia.org/wiki/YAML):
+The **default** configuration, represented as [YAML](https://en.wikipedia.org/wiki/YAML):
 
 ```yaml
 ---
@@ -52,6 +52,8 @@ application:
   name: null
   href: null
 ```
+
+See the [stormpath.yaml](#stormpath-json-yaml) section below for examples of properties not specified in the default configuration.
 
 ## Files
 

--- a/specifications/config.md
+++ b/specifications/config.md
@@ -53,7 +53,7 @@ application:
   href: null
 ```
 
->> :bulb: See the [stormpath.yaml](#stormpathjsonyaml) section below for examples of properties not specified in the default configuration.
+> :bulb: See the [stormpath.yaml](#stormpathjsonyaml) section below for examples of properties not specified in the default configuration.
 
 ## Files
 
@@ -85,7 +85,6 @@ client:
     defaultTtl: 300
     defaultTti: 300
     caches:
-      
       # Resource cache configurations, as needed.
       # These are used to override the default TTL/TTI settings
       # for a particular resource type.


### PR DESCRIPTION
Clarified that the **default** configuration doesn't include any resource-specific cache configurations. 

Also added comments to the YAML example to indicate how the resource-specific cache blocks work.
